### PR TITLE
Feature/greater equal epsilon normalized

### DIFF
--- a/docs/reference/constraints.rst
+++ b/docs/reference/constraints.rst
@@ -1,15 +1,15 @@
 Constraints
 ============
 
-Log Weight Constraints
-----------------------
-These should be used for log accumulators.
-
-.. autoclass:: libspn_keras.constraints.LogNormalize
-
-
 Linear Weight Constraints
 -------------------------
 These should be used for linear accumulators.
 
+.. autoclass:: libspn_keras.constraints.GreaterEqualEpsilonNormalized
 .. autoclass:: libspn_keras.constraints.GreaterEqualEpsilon
+
+Log Weight Constraints
+----------------------
+These should be used for log accumulators.
+
+.. autoclass:: libspn_keras.constraints.LogNormalized

--- a/docs/reference/initializers.rst
+++ b/docs/reference/initializers.rst
@@ -27,3 +27,4 @@ When training with either ``HARD_EM`` or ``HARD_EM_UNWEIGHTED``, you can use the
 ``EpsilonInverseFanIn`` initializer.
 
 .. autoclass:: libspn_keras.initializers.EpsilonInverseFanIn
+.. autoclass:: libspn_keras.initializers.Dirichlet

--- a/examples/notebooks/Benchmark With Einsums.ipynb
+++ b/examples/notebooks/Benchmark With Einsums.ipynb
@@ -1,0 +1,422 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "5STeGqw63l__"
+   },
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/pronobis/libspn-keras/blob/master/examples/notebooks/Benchmark%20With%20Einsum%20Networks.ipynb)\n",
+    "# Bench-marking LibSPN-Keras against EinsumNetworks\n",
+    "Recently, [Peharz et al.](https://arxiv.org/abs/2004.06231) proposed _Einsum Networks_, which are essentially SPNs with a specific implementation style. Einsum Networks implement a range of tricks that can be used to easily achieve tensor-based building of SPNs as well as EM learning through _autograd_. \n",
+    "\n",
+    "Fortunately, `libspn-keras` already had the same tricks implemented _ever since it was made available_ (before the Einsum paper was published), and so it was straightforward to set up a side-by-side comparison of `libspn-keras` \n",
+    "against the open-source implementation of Einsum Networks.\n",
+    "\n",
+    "## Installing Frameworks\n",
+    "`libspn-keras` is available on PyPI and so we'll simply use `pip` to install it. For `Einsum` we'll need to clone its repo and add it to our `PATH`.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 85
+    },
+    "id": "6bGer1RP3mAF",
+    "outputId": "9a736743-d95c-424d-8623-6d3eee97f03d"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fatal: destination path 'EinsumNetworks' already exists and is not an empty directory.\n",
+      "Processing ./libspn_keras-0.4.0-py3-none-any.whl\n",
+      "Installing collected packages: libspn-keras\n",
+      "Successfully installed libspn-keras-0.4.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "!git clone https://github.com/cambridge-mlg/EinsumNetworks & pip install libspn_keras --ignore-installed --no-deps"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "MGLXv70ol-ZX"
+   },
+   "source": [
+    "\n",
+    "\n",
+    "## Bench-marking Architecture\n",
+    "This notebook takes an architecture that was made available in the original Einsum Network repo. We increase the depth of the network and the number of sums and input distributions to get a better idea of how the `libspn-keras` and `Einsum` implementations scale.\n",
+    "\n",
+    "The architecture is an SPN that recursively splits variables in two balanced groups starting at the root node. The groups are assigned randomly. Splitting is done up until a `depth` (in this case 5). After that, the remaining groups are combined through 'factorized input distributions'. This means that the binary leaf indicators are each weighted and the multiplied with the remaining nodes in a group. This is repeated `num_repetitions` times.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "id": "p0yeY0Xe3mAB"
+   },
+   "outputs": [],
+   "source": [
+    "depth = 5\n",
+    "num_repetitions = 32\n",
+    "num_input_distributions = 32\n",
+    "num_sums = 32\n",
+    "\n",
+    "max_num_epochs = 3\n",
+    "batch_size = 100\n",
+    "online_em_frequency = 1\n",
+    "online_em_stepsize = 0.05"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "IPp--fdHiqbE"
+   },
+   "source": [
+    "## Running Einsum\n",
+    "The public Einsum implementation uses a Pytorch backend. We'll run it for 10 epochs on a binary dataset and report\n",
+    "- The number of parameters per layer\n",
+    "- The log likelihood on validation data once every epoch\n",
+    "- The log likelihood on test data at the very end\n",
+    "- The total time spent training and computing the log-likelihood for the validation at each epoch\n",
+    "\n",
+    "**NOTE**\n",
+    "\n",
+    "For the most interesting comparison, make sure the GPU is actually being used. You can select a GPU in Colab using the `Runtime` dropdown which should show a `Change runtime type` option."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 442
+    },
+    "id": "8eIlR4Bc3mAL",
+    "outputId": "c6d5977b-00b7-48f5-a2e2-c86c8598bed6"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Running on  cuda\n",
+      "EinsumNetwork(\n",
+      "  (einet_layers): ModuleList(\n",
+      "    (0): FactorizedLeafLayer(\n",
+      "      (ef_array): CategoricalArray()\n",
+      "    )\n",
+      "    (1): EinsumLayer()\n",
+      "    (2): EinsumLayer()\n",
+      "    (3): EinsumLayer()\n",
+      "    (4): EinsumLayer()\n",
+      "    (5): EinsumLayer()\n",
+      "    (6): EinsumMixingLayer()\n",
+      "  )\n",
+      ")\n",
+      "Number of input dist parameters\n",
+      "227328\n",
+      "Number of remaining sum parameters\n",
+      "[16777216, 8388608, 4194304, 2097152, 32768, 32]\n",
+      "Total trainable parameters\n",
+      "31717408\n",
+      "[0]   valid LL -76.9047509765625\n",
+      "[1]   valid LL -37.21986155790441\n",
+      "[2]   valid LL -36.9792524988511\n",
+      "Total time: 43.69 seconds\n",
+      "-37.363624970523205\n"
+     ]
+    }
+   ],
+   "source": [
+    "import sys\n",
+    "sys.path.append(\"EinsumNetworks/src\")\n",
+    "import time\n",
+    "\n",
+    "import torch\n",
+    "from EinsumNetwork import Graph, EinsumNetwork\n",
+    "import datasets\n",
+    "import csv\n",
+    "import numpy as np\n",
+    "\n",
+    "device = 'cuda' if torch.cuda.is_available() else 'cpu'\n",
+    "\n",
+    "print(\"Running on \", device)\n",
+    "\n",
+    "dataset = 'accidents'\n",
+    "\n",
+    "train_x_orig, test_x_orig, valid_x_orig = datasets.load_debd(dataset, dtype='float32')\n",
+    "\n",
+    "train_x = train_x_orig\n",
+    "test_x = test_x_orig\n",
+    "valid_x = valid_x_orig\n",
+    "\n",
+    "# to torch\n",
+    "train_x = torch.from_numpy(train_x).to(torch.device(device))\n",
+    "valid_x = torch.from_numpy(valid_x).to(torch.device(device))\n",
+    "test_x = torch.from_numpy(test_x).to(torch.device(device))\n",
+    "\n",
+    "train_N, num_dims = train_x.shape\n",
+    "valid_N = valid_x.shape[0]\n",
+    "test_N = test_x.shape[0]\n",
+    "\n",
+    "graph = Graph.random_binary_trees(num_var=train_x.shape[1], depth=depth, num_repetitions=num_repetitions)\n",
+    "\n",
+    "args = EinsumNetwork.Args(\n",
+    "    num_classes=1,\n",
+    "    num_input_distributions=num_input_distributions,\n",
+    "    exponential_family=EinsumNetwork.CategoricalArray,\n",
+    "    exponential_family_args={'K': 2},\n",
+    "    num_sums=num_sums,\n",
+    "    num_var=train_x.shape[1],\n",
+    "    online_em_frequency=1,\n",
+    "    online_em_stepsize=0.05)\n",
+    "\n",
+    "einet = EinsumNetwork.EinsumNetwork(graph, args)\n",
+    "einet.initialize()\n",
+    "einet.to(device)\n",
+    "print(einet)\n",
+    "\n",
+    "print(\"Number of input dist parameters\")\n",
+    "input_layer_param_count = np.prod(einet.einet_layers[0].ef_array.params.shape)\n",
+    "print(input_layer_param_count)\n",
+    "\n",
+    "print(\"Number of remaining sum parameters\")\n",
+    "remaining_param_counts = [np.prod(layer.params.shape) for layer in einet.einet_layers if hasattr(layer,'params')]\n",
+    "print(remaining_param_counts)\n",
+    "\n",
+    "print(\"Total trainable parameters\")\n",
+    "print(sum([input_layer_param_count] + remaining_param_counts))\n",
+    "\n",
+    "start = time.time()\n",
+    "for epoch_count in range(max_num_epochs):\n",
+    "\n",
+    "    # evaluate\n",
+    "    with torch.no_grad():\n",
+    "        # This bit differs from original implementation \n",
+    "        # (which did not disable grad, in other words this is to make this\n",
+    "        # part of the script run slightly faster)\n",
+    "        valid_ll = EinsumNetwork.eval_loglikelihood_batched(einet, valid_x)\n",
+    "\n",
+    "    # Also here we only report the validation LLH during our training epochs\n",
+    "    # which makes it similar to how one would do it using Keras (or libspn-keras)\n",
+    "    print(\"[{}]   valid LL {}\".format(epoch_count, valid_ll / valid_N))\n",
+    "    # train\n",
+    "    idx_batches = torch.randperm(train_N).split(batch_size)\n",
+    "    for batch_count, idx in enumerate(idx_batches):\n",
+    "        batch_x = train_x[idx, :]\n",
+    "        outputs = einet.forward(batch_x)\n",
+    "\n",
+    "        ll_sample = EinsumNetwork.log_likelihoods(outputs)\n",
+    "        log_likelihood = ll_sample.sum()\n",
+    "\n",
+    "        objective = log_likelihood\n",
+    "        objective.backward()\n",
+    "\n",
+    "        einet.em_process_batch()\n",
+    "\n",
+    "    einet.em_update()\n",
+    "\n",
+    "print(f\"Total time: {time.time() - start:.2f} seconds\")\n",
+    "with torch.no_grad():\n",
+    "    test_ll = EinsumNetwork.eval_loglikelihood_batched(einet, test_x)\n",
+    "print(test_ll / test_N)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "zsX8X_qqjogG"
+   },
+   "source": [
+    "## Quick Analysis\n",
+    "We see the following interesting things:\n",
+    "- A test LLH of around -37.36\n",
+    "- A total train time of 43.69 seconds\n",
+    "- Total number of trainable parameters 31,717,408 \n",
+    "\n",
+    "## LibSPN-Keras Implementation\n",
+    "Instead of hiding all the complexity behind a `Graph.random_binary_trees`, `libspn-keras` offers a layer-based approach that offers the ability to control all network parameters flexibly at every layer. In that sense, we are in no sense forced to use the same number of sums for every layer, nor a fixed number of 2 children per product. We can easily vary all of these parameters. Nevertheless, for the sake of comparison we'll reimplement the above architecture using `libspn-keras`.\n",
+    "\n",
+    "Let's see how they compare!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 833
+    },
+    "id": "5HuP4SJT3mAO",
+    "outputId": "57f50dbf-3397-4839-e4cb-0ad997ce520f"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model: \"sequential_sum_product_network_3\"\n",
+      "_________________________________________________________________\n",
+      "Layer (type)                 Output Shape              Param #   \n",
+      "=================================================================\n",
+      "flat_to_regions_3 (FlatToReg (None, 111, 32, 1)        0         \n",
+      "_________________________________________________________________\n",
+      "indicator_leaf_3 (IndicatorL (None, 111, 32, 2)        0         \n",
+      "_________________________________________________________________\n",
+      "dense_sum_19 (DenseSum)      (None, 111, 32, 32)       227328    \n",
+      "_________________________________________________________________\n",
+      "permute_and_pad_scopes_rando (None, 128, 32, 32)       4096      \n",
+      "_________________________________________________________________\n",
+      "reduce_product_3 (ReduceProd (None, 32, 32, 32)        0         \n",
+      "_________________________________________________________________\n",
+      "dense_product_16 (DenseProdu (None, 16, 32, 1024)      0         \n",
+      "_________________________________________________________________\n",
+      "dense_sum_20 (DenseSum)      (None, 16, 32, 32)        16777216  \n",
+      "_________________________________________________________________\n",
+      "dense_product_17 (DenseProdu (None, 8, 32, 1024)       0         \n",
+      "_________________________________________________________________\n",
+      "dense_sum_21 (DenseSum)      (None, 8, 32, 32)         8388608   \n",
+      "_________________________________________________________________\n",
+      "dense_product_18 (DenseProdu (None, 4, 32, 1024)       0         \n",
+      "_________________________________________________________________\n",
+      "dense_sum_22 (DenseSum)      (None, 4, 32, 32)         4194304   \n",
+      "_________________________________________________________________\n",
+      "dense_product_19 (DenseProdu (None, 2, 32, 1024)       0         \n",
+      "_________________________________________________________________\n",
+      "dense_sum_23 (DenseSum)      (None, 2, 32, 32)         2097152   \n",
+      "_________________________________________________________________\n",
+      "dense_product_20 (DenseProdu (None, 1, 32, 1024)       0         \n",
+      "_________________________________________________________________\n",
+      "dense_sum_24 (DenseSum)      (None, 1, 32, 1)          32768     \n",
+      "_________________________________________________________________\n",
+      "root_sum_3 (RootSum)         (None, 1)                 32        \n",
+      "=================================================================\n",
+      "Total params: 31,721,504\n",
+      "Trainable params: 31,717,408\n",
+      "Non-trainable params: 4,096\n",
+      "_________________________________________________________________\n",
+      "Epoch 1/3\n",
+      "128/128 [==============================] - 7s 58ms/step - loss: 41.6101 - llh: -41.6101 - val_loss: 37.1047 - val_llh: -37.1047\n",
+      "Epoch 2/3\n",
+      "128/128 [==============================] - 7s 55ms/step - loss: 37.1014 - llh: -37.1014 - val_loss: 36.8422 - val_llh: -36.8422\n",
+      "Epoch 3/3\n",
+      "128/128 [==============================] - 7s 55ms/step - loss: 36.9422 - llh: -36.9422 - val_loss: 36.7074 - val_llh: -36.7074\n",
+      "Total time: 23.43 seconds\n",
+      "1/1 [==============================] - 0s 2ms/step - loss: 37.1249 - llh: -37.1249\n"
+     ]
+    }
+   ],
+   "source": [
+    "import libspn_keras as spnk\n",
+    "import itertools\n",
+    "import tensorflow as tf\n",
+    "\n",
+    "def build_ratspn(num_vars, depth):\n",
+    "    # Set global settings\n",
+    "    spnk.set_default_sum_op(spnk.SumOpEMBackprop())\n",
+    "    spnk.set_default_accumulator_initializer(tf.keras.initializers.RandomUniform())\n",
+    "    \n",
+    "    # Define stack\n",
+    "    sum_product_stack = [\n",
+    "        # Create repetitions, nodes and scope axes\n",
+    "        spnk.layers.FlatToRegions(num_decomps=num_repetitions, input_shape=[num_vars], dtype=tf.int32),\n",
+    "        # Add binary variables\n",
+    "        spnk.layers.IndicatorLeaf(num_components=2), \n",
+    "        # Add dense sum layer (effectively computing the input distributions)\n",
+    "        spnk.layers.DenseSum(num_sums=num_input_distributions),\n",
+    "        # Randomly permute scopes and pad if necessary\n",
+    "        spnk.layers.PermuteAndPadScopesRandom(),\n",
+    "        # Products through reduction correspond to Einsum's notion of \n",
+    "        # 'factorized' distributions\n",
+    "        spnk.layers.ReduceProduct(num_factors=int(np.ceil(num_vars / 2 ** depth))),\n",
+    "    ]\n",
+    "    for i in range(depth):\n",
+    "        # The alternating stacks of remaining product and sum layers\n",
+    "        sum_product_stack += [\n",
+    "            spnk.layers.DenseProduct(num_factors=2),\n",
+    "            spnk.layers.DenseSum(num_sums=num_sums if i < depth - 1 else 1),\n",
+    "        ]\n",
+    "    sum_product_stack.append(\n",
+    "        spnk.layers.RootSum(return_weighted_child_logits=False)\n",
+    "    )\n",
+    "    return spnk.models.SequentialSumProductNetwork(sum_product_stack)\n",
+    "\n",
+    "train_ds = tf.data.Dataset.from_tensor_slices((train_x_orig,)).shuffle(10_000).batch(batch_size)\n",
+    "valid_ds = tf.data.Dataset.from_tensor_slices((valid_x_orig,)).batch(len(valid_x_orig))\n",
+    "test_ds = tf.data.Dataset.from_tensor_slices((test_x_orig,)).batch(len(test_x_orig))\n",
+    "\n",
+    "spn = build_ratspn(train_x_orig.shape[1], depth=depth)\n",
+    "\n",
+    "spn.compile(\n",
+    "    loss=spnk.losses.NegativeLogLikelihood(),\n",
+    "    metrics=[spnk.metrics.LogLikelihood()],\n",
+    "    optimizer=spnk.optimizers.OnlineExpectationMaximization(learning_rate=0.05)\n",
+    ")\n",
+    "\n",
+    "spn.summary()\n",
+    "\n",
+    "start = time.time()\n",
+    "spn.fit(train_ds, validation_data=valid_ds, epochs=max_num_epochs)\n",
+    "print(f\"Total time: {time.time() - start:.2f} seconds\")\n",
+    "\n",
+    "evaluation = spn.evaluate(test_ds)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "aiM-eHeCicUt"
+   },
+   "source": [
+    "## Analysis\n",
+    "We now see the following\n",
+    "- A test LLH of around -37.12 (not significantly different which makes sense)\n",
+    "- A total train time of **23.43** seconds\n",
+    "- Total number of trainable parameters 31,717,408 (same as above just as a sanity check)\n",
+    "\n",
+    "In other words, `libspn-keras` is not just more flexible, but also almost twice as fast here!"
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "name": "Benchmark With Einsums.ipynb",
+   "provenance": [],
+   "toc_visible": true
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/notebooks/DGC-SPN Image Classification.ipynb
+++ b/examples/notebooks/DGC-SPN Image Classification.ipynb
@@ -7,7 +7,7 @@
     "id": "cw8l-b_NIaBy"
    },
    "source": [
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/pronobis/libspn-keras/blob/add-tooling/examples/notebooks/DGC-SPN%20Image%20Classification.ipynb)\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/pronobis/libspn-keras/blob/master/examples/notebooks/DGC-SPN%20Image%20Classification.ipynb)\n",
     "\n",
     "# **Image Classification**: A Deep Generalized Convolutional Sum-Product Network (DGC-SPN) with `libspn-keras`\n",
     "Let's go through an example of building complex SPNs with [`libspn-keras`](https://github.com/pronobis/libspn-keras). The layer-based API of the library makes it straightforward to build advanced SPN architectures.\n",
@@ -81,6 +81,7 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### Defining the Architecture\n",
     "We begin by using non-overlapping convolution patches for our first two product layers,\n",
@@ -90,14 +91,20 @@
     "remainder of the product layers, we'll use *exponentially increasing dilation rates*. By doing so, we have\n",
     "'overlapping' patches that still yield a valid SPN. These exponentially increasing dilation rates for convolutional SPNs were first\n",
     "introduced in [this paper](https://arxiv.org/abs/1902.06155)."
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "sum_product_network = keras.Sequential([\n",
@@ -169,13 +176,7 @@
     "])\n",
     "\n",
     "sum_product_network.summary()"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",

--- a/libspn_keras/__init__.py
+++ b/libspn_keras/__init__.py
@@ -20,6 +20,14 @@ from libspn_keras.config.accumulator_initializer import (
     get_default_accumulator_initializer,
     set_default_accumulator_initializer,
 )
+from libspn_keras.config.linear_accumulator_constraint import (
+    get_default_linear_accumulators_constraint,
+    set_default_linear_accumulators_constraint,
+)
+from libspn_keras.config.logspace_accumulator_constraint import (
+    get_default_logspace_accumulators_constraint,
+    set_default_logspace_accumulators_constraint,
+)
 from libspn_keras.config.sum_op import get_default_sum_op, set_default_sum_op
 from libspn_keras.logspace import logspace_wrapper_initializer
 from libspn_keras.region import region_graph_to_dense_spn
@@ -38,6 +46,10 @@ __all__ = [
     "config",
     "get_default_accumulator_initializer",
     "set_default_accumulator_initializer",
+    "set_default_logspace_accumulators_constraint",
+    "set_default_linear_accumulators_constraint",
+    "get_default_linear_accumulators_constraint",
+    "get_default_logspace_accumulators_constraint",
     "get_default_sum_op",
     "set_default_sum_op",
     "logspace_wrapper_initializer",

--- a/libspn_keras/config/accumulator_initializer.py
+++ b/libspn_keras/config/accumulator_initializer.py
@@ -1,6 +1,8 @@
-from tensorflow.keras.initializers import Initializer, TruncatedNormal
+from tensorflow.keras.initializers import Initializer
 
-_DEFAULT_ACCUMULATOR_INITIALIZER = TruncatedNormal(stddev=0.5, mean=1.0)
+from libspn_keras.initializers.dirichlet import Dirichlet
+
+_DEFAULT_ACCUMULATOR_INITIALIZER = Dirichlet(alpha=1.0, axis=-2)
 
 
 def set_default_accumulator_initializer(initializer: Initializer) -> None:

--- a/libspn_keras/config/linear_accumulator_constraint.py
+++ b/libspn_keras/config/linear_accumulator_constraint.py
@@ -1,24 +1,25 @@
+from typing import Optional
+
 from tensorflow.keras.constraints import Constraint
 
 from libspn_keras.constraints.greater_equal_epsilon_normalized import (
     GreaterEqualEpsilonNormalized,
 )
 
-_DEFAULT_LINEAR_ACCUMULATOR_CONSTRAINT = None
+
+_DEFAULT_LINEAR_ACCUMULATOR_CONSTRAINT: Optional[
+    Constraint
+] = GreaterEqualEpsilonNormalized()
 
 
-def get_default_linear_accumulators_constraint() -> Constraint:
+def get_default_linear_accumulators_constraint() -> Optional[Constraint]:
     """
     Get default linear accumulator constraint.
 
     Returns:
         A ``Constraint`` instance that was set with ``set_default_linear_accumulators_constraint``
     """
-    return (
-        GreaterEqualEpsilonNormalized()
-        if _DEFAULT_LINEAR_ACCUMULATOR_CONSTRAINT is None
-        else _DEFAULT_LINEAR_ACCUMULATOR_CONSTRAINT
-    )
+    return _DEFAULT_LINEAR_ACCUMULATOR_CONSTRAINT
 
 
 def set_default_linear_accumulators_constraint(op: Constraint) -> None:

--- a/libspn_keras/config/linear_accumulator_constraint.py
+++ b/libspn_keras/config/linear_accumulator_constraint.py
@@ -1,0 +1,32 @@
+from tensorflow.keras.constraints import Constraint
+
+from libspn_keras.constraints.greater_equal_epsilon_normalized import (
+    GreaterEqualEpsilonNormalized,
+)
+
+_DEFAULT_LINEAR_ACCUMULATOR_CONSTRAINT = None
+
+
+def get_default_linear_accumulators_constraint() -> Constraint:
+    """
+    Get default linear accumulator constraint.
+
+    Returns:
+        A ``Constraint`` instance that was set with ``set_default_linear_accumulators_constraint``
+    """
+    return (
+        GreaterEqualEpsilonNormalized()
+        if _DEFAULT_LINEAR_ACCUMULATOR_CONSTRAINT is None
+        else _DEFAULT_LINEAR_ACCUMULATOR_CONSTRAINT
+    )
+
+
+def set_default_linear_accumulators_constraint(op: Constraint) -> None:
+    """
+    Set default sum op to conveniently use it throughout an SPN architecture.
+
+    Args:
+        op: A constraint applied to linear accumulators after updates
+    """
+    global _DEFAULT_LINEAR_ACCUMULATOR_CONSTRAINT
+    _DEFAULT_LINEAR_ACCUMULATOR_CONSTRAINT = op

--- a/libspn_keras/config/logspace_accumulator_constraint.py
+++ b/libspn_keras/config/logspace_accumulator_constraint.py
@@ -1,0 +1,30 @@
+from tensorflow.keras.constraints import Constraint
+
+from libspn_keras.constraints.log_normalized import LogNormalized
+
+_DEFAULT_LOGSPACE_ACCUMULATOR_CONSTRAINT = None
+
+
+def get_default_logspace_accumulators_constraint() -> Constraint:
+    """
+    Get default logspace accumulator constraint.
+
+    Returns:
+        A ``Constraint`` instance that was set with ``set_default_logspace_accumulators_constraint``
+    """
+    return (
+        LogNormalized()
+        if _DEFAULT_LOGSPACE_ACCUMULATOR_CONSTRAINT is None
+        else _DEFAULT_LOGSPACE_ACCUMULATOR_CONSTRAINT
+    )
+
+
+def set_default_logspace_accumulators_constraint(op: Constraint) -> None:
+    """
+    Set default sum op to conveniently use it throughout an SPN architecture.
+
+    Args:
+        op: A constraint applied to logspace accumulators after updates
+    """
+    global _DEFAULT_LOGSPACE_ACCUMULATOR_CONSTRAINT
+    _DEFAULT_LOGSPACE_ACCUMULATOR_CONSTRAINT = op

--- a/libspn_keras/config/logspace_accumulator_constraint.py
+++ b/libspn_keras/config/logspace_accumulator_constraint.py
@@ -1,22 +1,21 @@
+from typing import Optional
+
 from tensorflow.keras.constraints import Constraint
 
 from libspn_keras.constraints.log_normalized import LogNormalized
 
-_DEFAULT_LOGSPACE_ACCUMULATOR_CONSTRAINT = None
+
+_DEFAULT_LOGSPACE_ACCUMULATOR_CONSTRAINT: Optional[Constraint] = LogNormalized()
 
 
-def get_default_logspace_accumulators_constraint() -> Constraint:
+def get_default_logspace_accumulators_constraint() -> Optional[Constraint]:
     """
     Get default logspace accumulator constraint.
 
     Returns:
         A ``Constraint`` instance that was set with ``set_default_logspace_accumulators_constraint``
     """
-    return (
-        LogNormalized()
-        if _DEFAULT_LOGSPACE_ACCUMULATOR_CONSTRAINT is None
-        else _DEFAULT_LOGSPACE_ACCUMULATOR_CONSTRAINT
-    )
+    return _DEFAULT_LOGSPACE_ACCUMULATOR_CONSTRAINT
 
 
 def set_default_logspace_accumulators_constraint(op: Constraint) -> None:

--- a/libspn_keras/constraints/__init__.py
+++ b/libspn_keras/constraints/__init__.py
@@ -1,5 +1,5 @@
 from .greater_equal_epsilon import GreaterEqualEpsilon
 from .greater_equal_epsilon_normalized import GreaterEqualEpsilonNormalized
-from .log_normalize import LogNormalize
+from .log_normalized import LogNormalized
 
-__all__ = ["GreaterEqualEpsilon", "GreaterEqualEpsilonNormalized", "LogNormalize"]
+__all__ = ["GreaterEqualEpsilon", "GreaterEqualEpsilonNormalized", "LogNormalized"]

--- a/libspn_keras/constraints/greater_equal_epsilon_normalized.py
+++ b/libspn_keras/constraints/greater_equal_epsilon_normalized.py
@@ -24,7 +24,9 @@ class GreaterEqualEpsilonNormalized(Constraint):
         Returns:
             Clipped weight Tensor.
         """
-        clipped = tf.maximum(w, self.epsilon)
+        clipped = tf.maximum(
+            w, self.epsilon / tf.cast(tf.shape(w)[self.axis], tf.float32)
+        )
         return clipped / tf.reduce_sum(clipped, axis=self.axis, keepdims=True)
 
     def get_config(self) -> dict:

--- a/libspn_keras/constraints/log_normalized.py
+++ b/libspn_keras/constraints/log_normalized.py
@@ -4,7 +4,7 @@ import tensorflow as tf
 from tensorflow.keras.constraints import Constraint
 
 
-class LogNormalize(Constraint):
+class LogNormalized(Constraint):
     """
     Normalizes log-space weights.
 

--- a/libspn_keras/initializers/__init__.py
+++ b/libspn_keras/initializers/__init__.py
@@ -1,9 +1,11 @@
+from libspn_keras.initializers.dirichlet import Dirichlet
 from libspn_keras.initializers.epsilon_inverse_fan_in import EpsilonInverseFanIn
 from libspn_keras.initializers.equidistant import Equidistant
 from libspn_keras.initializers.kmeans import KMeans
 from libspn_keras.initializers.poon_domingos import PoonDomingosMeanOfQuantileSplit
 
 __all__ = [
+    "Dirichlet",
     "EpsilonInverseFanIn",
     "Equidistant",
     "PoonDomingosMeanOfQuantileSplit",

--- a/libspn_keras/initializers/dirichlet.py
+++ b/libspn_keras/initializers/dirichlet.py
@@ -10,9 +10,9 @@ class Dirichlet(initializers.Initializer):
     Initializes all values in a tensor with :math:`Dir(\alpha)`.
 
     Args:
-        axis: The axis for input nodes so that :math:`K^{-1}` is the inverse fan in. Usually,
-            this is ``-2``.
-        epsilon: A small non-zero constant
+        axis: The axis over which to sample from a :math:`Dir(\alpha)`.
+        alpha: The :math:`\alpha` parameter of the Dirichlet distribution.
+            If a scalar, this is broadcast along the given axis.
     """
 
     def __init__(

--- a/libspn_keras/initializers/dirichlet.py
+++ b/libspn_keras/initializers/dirichlet.py
@@ -1,0 +1,62 @@
+from typing import Optional, Tuple
+
+import tensorflow as tf
+from tensorflow.keras import initializers
+from tensorflow_probability import distributions
+
+
+class Dirichlet(initializers.Initializer):
+    r"""
+    Initializes all values in a tensor with :math:`Dir(\alpha)`.
+
+    Args:
+        axis: The axis for input nodes so that :math:`K^{-1}` is the inverse fan in. Usually,
+            this is ``-2``.
+        epsilon: A small non-zero constant
+    """
+
+    def __init__(
+        self, axis: int = -2, alpha: float = 0.1,
+    ):
+        self.axis = axis
+        self.alpha = alpha
+
+    def __call__(
+        self, shape: Tuple[int, ...], dtype: Optional[tf.DType] = None
+    ) -> tf.Tensor:
+        """
+        Compute initializations along the given axis.
+
+        Args:
+            shape: Shape of Tensor to initialize.
+            dtype: DType of Tensor to initialize.
+
+        Returns:
+            Initial value.
+        """
+        axis = (len(shape) + self.axis) % len(shape)
+
+        alpha_as_tensor = tf.convert_to_tensor(self.alpha)
+        alpha = (
+            tf.tile([alpha_as_tensor], [shape[axis]])
+            if tf.size(alpha_as_tensor) == 1
+            else alpha_as_tensor
+        )
+        dirichlet_sample = distributions.Dirichlet(concentration=alpha).sample(
+            [dim for i, dim in enumerate(shape) if i != axis]
+        )
+
+        perm = [
+            i if i < axis else len(shape) - 1 if i == axis else i - 1
+            for i in range(len(shape))
+        ]
+        return tf.cast(tf.transpose(dirichlet_sample, perm), dtype)
+
+    def get_config(self) -> dict:
+        """
+        Obtain the config.
+
+        Returns:
+            Key-value mapping with the configuration of this initializer.
+        """
+        return {"alpha": self.alpha, "axis": self.axis}

--- a/libspn_keras/layers/conv2d_sum.py
+++ b/libspn_keras/layers/conv2d_sum.py
@@ -70,4 +70,5 @@ class Conv2DSum(DenseSum):
             x,
             accumulators=self._accumulators,
             logspace_accumulators=self.logspace_accumulators,
+            normalize_in_forward_pass=self._forward_normalize,
         )

--- a/libspn_keras/layers/permute_and_pad_scopes_random.py
+++ b/libspn_keras/layers/permute_and_pad_scopes_random.py
@@ -98,6 +98,7 @@ class PermuteAndPadScopesRandom(PermuteAndPadScopes):
                 for i in range(num_m1):
                     p.insert(i * rate_m1, -1)
         self.permutations = self.add_weight(
+            name="permutations",
             initializer=initializers.Constant(perms),
             trainable=False,
             shape=[num_decomps, factor_prod],

--- a/libspn_keras/layers/root_sum.py
+++ b/libspn_keras/layers/root_sum.py
@@ -95,13 +95,18 @@ class RootSum(DenseSum):
             input_shape: Shape of the input Tensor.
 
         Raises:
-            ValueError: Raised when the number of input scopes does not equal 1.
+            ValueError: Raised when the number of input scopes does not equal 1, or
+                if number of decompositions or nodes in the input is unknown.
         """
         num_batch, num_scopes, num_decomps, num_nodes = input_shape
         if num_scopes != 1:
             raise ValueError(
                 f"Expected to have 1 scope at the input of a RootSum, got {num_scopes}"
             )
+        if num_decomps is None:
+            raise ValueError("Must have known number of decompositions")
+        if num_nodes is None:
+            raise ValueError("Must have known number of nodes")
         super(RootSum, self).build((num_batch, num_scopes, 1, num_decomps * num_nodes))
 
     def compute_output_shape(
@@ -115,8 +120,17 @@ class RootSum(DenseSum):
 
         Returns:
             Tuple of ints holding the output shape of the layer.
+
+
+        Raises:
+            ValueError: Raised when the number of decompositions
+                or nodes in the input is unknown.
         """
         num_batch, _, num_decomps, num_nodes_in = input_shape
+        if num_decomps is None:
+            raise ValueError("Must have known number of decompositions")
+        if num_nodes_in is None:
+            raise ValueError("Must have known number of nodes")
         return (
             num_batch,
             num_decomps * num_nodes_in

--- a/libspn_keras/layers/root_sum.py
+++ b/libspn_keras/layers/root_sum.py
@@ -43,7 +43,7 @@ class RootSum(DenseSum):
         accumulator_regularizer: Optional[tf.keras.regularizers.Regularizer] = None,
         linear_accumulator_constraint: Optional[tf.keras.constraints.Constraint] = None,
         sum_op: Optional[SumOpBase] = None,
-        **kwargs
+        **kwargs,
     ):
         super(RootSum, self).__init__(
             logspace_accumulators=logspace_accumulators,
@@ -54,7 +54,7 @@ class RootSum(DenseSum):
             linear_accumulator_constraint=linear_accumulator_constraint,
             sum_op=sum_op,
             num_sums=1,
-            **kwargs
+            **kwargs,
         )
         self.return_weighted_child_logits = return_weighted_child_logits
 
@@ -72,17 +72,37 @@ class RootSum(DenseSum):
         Returns:
             Sum or weighted children.
         """
+        x_reshaped = tf.reshape(x, (-1, 1, 1, self._num_nodes_in))
+
         if self.return_weighted_child_logits:
             out = self.sum_op.weighted_children(
-                x,
+                x_reshaped,
                 accumulators=self._accumulators,
                 logspace_accumulators=self.logspace_accumulators,
+                normalize_in_forward_pass=self._forward_normalize,
             )
             num_out = self._accumulators.shape[2]
         else:
-            out = super(RootSum, self).call(x, **kwargs)
+            out = super(RootSum, self).call(x_reshaped, **kwargs)
             num_out = 1
         return tf.reshape(out, [-1, num_out])
+
+    def build(self, input_shape: Tuple[Optional[int], ...]) -> None:
+        """
+        Build the internal components for this layer.
+
+        Args:
+            input_shape: Shape of the input Tensor.
+
+        Raises:
+            ValueError: Raised when the number of input scopes does not equal 1.
+        """
+        num_batch, num_scopes, num_decomps, num_nodes = input_shape
+        if num_scopes != 1:
+            raise ValueError(
+                f"Expected to have 1 scope at the input of a RootSum, got {num_scopes}"
+            )
+        super(RootSum, self).build((num_batch, num_scopes, 1, num_decomps * num_nodes))
 
     def compute_output_shape(
         self, input_shape: Tuple[Optional[int], ...]
@@ -96,10 +116,12 @@ class RootSum(DenseSum):
         Returns:
             Tuple of ints holding the output shape of the layer.
         """
-        num_batch, _, _, num_nodes_in = input_shape
+        num_batch, _, num_decomps, num_nodes_in = input_shape
         return (
             num_batch,
-            num_nodes_in if self.return_weighted_child_logits else num_batch,
+            num_decomps * num_nodes_in
+            if self.return_weighted_child_logits
+            else num_batch,
         )
 
     def get_config(self) -> dict:

--- a/libspn_keras/metrics/log_likelihood.py
+++ b/libspn_keras/metrics/log_likelihood.py
@@ -12,7 +12,7 @@ class LogLikelihood(keras.metrics.Mean):
     since a target for :math:`Y` is absent in unsupervised learning.
     """
 
-    def __init__(self, name: str = "log_marginal", **kwargs):
+    def __init__(self, name: str = "llh", **kwargs):
         super(LogLikelihood, self).__init__(name=name, **kwargs)
 
     def update_state(

--- a/libspn_keras/optimizers/online_expectation_maximization.py
+++ b/libspn_keras/optimizers/online_expectation_maximization.py
@@ -8,5 +8,9 @@ class OnlineExpectationMaximization(keras.optimizers.SGD):
     Internally, this is just an SGD optimizer with unit learning rate.
     """
 
-    def __init__(self):
-        super(OnlineExpectationMaximization, self).__init__(learning_rate=1.0)
+    def __init__(
+        self, learning_rate: float = 0.05, gliding_average: bool = True, **kwargs
+    ):
+        if gliding_average:
+            learning_rate = -learning_rate / (learning_rate - 1.0)
+        super().__init__(learning_rate, **kwargs)

--- a/libspn_keras/sum_ops.py
+++ b/libspn_keras/sum_ops.py
@@ -467,13 +467,7 @@ class SumOpHardEMBackprop(SumOpBase):
                 child_counts = tf.reduce_sum(per_sample_weight_counts, axis=3)
                 weight_counts = tf.reduce_sum(per_sample_weight_counts, axis=2)
 
-                weight_counts = accumulators * tf.linalg.matrix_transpose(weight_counts)
-
-                weight_counts /= (
-                    tf.reduce_sum(tf.abs(weight_counts), axis=2, keepdims=True) + 1e-16
-                )
-
-                return child_counts, weight_counts
+                return child_counts, tf.transpose(weight_counts, (0, 1, 3, 2))
 
             return out, grad
 
@@ -610,13 +604,7 @@ class SumOpHardEMBackprop(SumOpBase):
                 # Sum over spatial axes
                 weight_counts = tf.reduce_sum(weight_counts, axis=[0, 1], keepdims=True)
 
-                weight_counts = accumulators * tf.linalg.matrix_transpose(weight_counts)
-
-                weight_counts /= (
-                    tf.reduce_sum(tf.abs(weight_counts), axis=2, keepdims=True) + 1e-16
-                )
-
-                return child_counts, weight_counts
+                return child_counts, tf.linalg.matrix_transpose(weight_counts)
 
             return out, grad
 
@@ -648,6 +636,7 @@ class SumOpUnweightedHardEMBackprop(SumOpBase):
     def __init__(self, sample_prob: Optional[Union[float, tf.Tensor]] = None):
         self.sample_prob = sample_prob
 
+    @_batch_scope_tranpose
     def weighted_sum(
         self,
         x: tf.Tensor,
@@ -725,13 +714,6 @@ class SumOpUnweightedHardEMBackprop(SumOpBase):
                 weight_counts = tf.matmul(
                     winning_child_per_scope_one_hot, parent_counts, transpose_a=True
                 )
-
-                weight_counts = accumulators * weight_counts
-
-                weight_counts /= (
-                    tf.reduce_sum(tf.abs(weight_counts), axis=2, keepdims=True) + 1e-16
-                )
-
                 return child_counts, weight_counts
 
             return out, grad
@@ -850,13 +832,6 @@ class SumOpUnweightedHardEMBackprop(SumOpBase):
                     winning_child_per_scope_one_hot, parent_counts, transpose_a=True
                 )
                 weight_counts = tf.reduce_sum(weight_counts, axis=[0, 1], keepdims=True)
-
-                weight_counts = accumulators * tf.linalg.matrix_transpose(weight_counts)
-
-                weight_counts /= (
-                    tf.reduce_sum(tf.abs(weight_counts), axis=2, keepdims=True) + 1e-16
-                )
-
                 return child_counts, weight_counts
 
             return out, grad

--- a/libspn_keras/sum_ops.py
+++ b/libspn_keras/sum_ops.py
@@ -29,7 +29,11 @@ class SumOpBase(abc.ABC):
 
     @abc.abstractmethod
     def weighted_sum(
-        self, x: tf.Tensor, accumulators: tf.Tensor, logspace_accumulators: bool
+        self,
+        x: tf.Tensor,
+        accumulators: tf.Tensor,
+        logspace_accumulators: bool,
+        normalize_in_forward_pass: bool,
     ) -> tf.Tensor:
         """
         Implement sum operation on log inputs X and accumulators w.
@@ -38,11 +42,16 @@ class SumOpBase(abc.ABC):
             x: Input Tensor.
             accumulators: Unnormalized accumulators.
             logspace_accumulators: Whether accumulators are in logspace.
+            normalize_in_forward_pass: Whether weights should be normalized during forward inference.
         """
 
     @abc.abstractmethod
     def weighted_children(
-        self, x: tf.Tensor, accumulators: tf.Tensor, logspace_accumulators: bool
+        self,
+        x: tf.Tensor,
+        accumulators: tf.Tensor,
+        logspace_accumulators: bool,
+        normalize_in_forward_pass: bool,
     ) -> tf.Tensor:
         """
         Compute weighted children (used in RootSum).
@@ -51,11 +60,16 @@ class SumOpBase(abc.ABC):
             x: Input Tensor.
             accumulators: Unnormalized accumulators.
             logspace_accumulators: Whether accumulators are in logspace.
+            normalize_in_forward_pass: Whether weights should be normalized during forward inference.
         """
 
     @abc.abstractmethod
     def weighted_conv(
-        self, x: tf.Tensor, accumulators: tf.Tensor, logspace_accumulators: bool
+        self,
+        x: tf.Tensor,
+        accumulators: tf.Tensor,
+        logspace_accumulators: bool,
+        normalize_in_forward_pass: bool,
     ) -> tf.Tensor:
         """
         Compute weighted convolution (used in ConvSum).
@@ -64,6 +78,7 @@ class SumOpBase(abc.ABC):
             x: Input Tensor.
             accumulators: Unnormalized accumulators.
             logspace_accumulators: Whether accumulators are in logspace.
+            normalize_in_forward_pass: Whether weights should be normalized during forward inference.
         """
 
     @abc.abstractmethod
@@ -80,11 +95,46 @@ class SumOpBase(abc.ABC):
         with tf.name_scope("LogNormalize"):
             return tf.nn.log_softmax(x, axis=-2)
 
-    @tf.custom_gradient
     def _to_logspace_override_grad(
-        self, accumulators: tf.Tensor
+        self, accumulators: tf.Tensor, normalize_in_forward_pass: bool
     ) -> Tuple[tf.Tensor, Callable[[tf.Tensor], tf.Tensor]]:
-        return self._to_log_weights(accumulators), lambda dy: dy
+        @tf.custom_gradient
+        def _inner(
+            accumulators: tf.Tensor,
+        ) -> Tuple[tf.Tensor, Callable[[tf.Tensor], tf.Tensor]]:
+            if normalize_in_forward_pass:
+                return (
+                    self._to_log_weights(accumulators),
+                    lambda dy: dy
+                    / (tf.abs(tf.reduce_sum(dy, axis=2, keepdims=True)) + 1e-20),
+                )
+            else:
+                return (
+                    tf.math.log(accumulators),
+                    lambda dy: dy
+                    / (tf.abs(tf.reduce_sum(dy, axis=2, keepdims=True)) + 1e-20),
+                )
+
+        return _inner(accumulators)
+
+    def _weights_in_logspace(
+        self,
+        accumulators: tf.Tensor,
+        logspace_accumulators: bool,
+        normalize_in_forward_pass: bool,
+    ) -> tf.Tensor:
+        if logspace_accumulators:
+            return (
+                self._log_normalize(accumulators)
+                if normalize_in_forward_pass
+                else accumulators
+            )
+        else:
+            return (
+                self._to_log_weights(accumulators)
+                if normalize_in_forward_pass
+                else tf.math.log(accumulators)
+            )
 
 
 class SumOpGradBackprop(SumOpBase):
@@ -95,15 +145,26 @@ class SumOpGradBackprop(SumOpBase):
 
     Args:
             logspace_accumulators: If provided overrides default log-space choice. For a
-                ``SumOpGradBackprop`` the default is ``True``.
+                ``SumOpGradBackprop`` the default is ``True``
+            normalize_in_forward_pass: If provided overrides normalize that would otherwise be
+                determined from the constraints that are used for a sum layer's weights.
     """
 
-    def __init__(self, logspace_accumulators: Optional[bool] = None):
+    def __init__(
+        self,
+        logspace_accumulators: Optional[bool] = None,
+        normalize_in_forward_pass: Optional[bool] = None,
+    ):
         self._logspace_accumulators = logspace_accumulators
+        self._normalize = normalize_in_forward_pass
 
     @_batch_scope_tranpose
     def weighted_sum(
-        self, x: tf.Tensor, accumulators: tf.Tensor, logspace_accumulators: bool
+        self,
+        x: tf.Tensor,
+        accumulators: tf.Tensor,
+        logspace_accumulators: bool,
+        normalize_in_forward_pass: bool,
     ) -> tf.Tensor:
         """
         Compute a weighted sum.
@@ -111,20 +172,24 @@ class SumOpGradBackprop(SumOpBase):
         Args:
             x: Input Tensor
             accumulators: Accumulators, can be seen as unnormalized representations of weights.
-            logspace_accumulators: Whether or not accumulators are represented in logspaace.
+            logspace_accumulators: Whether or not accumulators are represented in logspace.
+            normalize_in_forward_pass: Whether weights should be normalized during forward inference.
 
         Returns:
             A Tensor with the weighted sums.
         """
-        w = (
-            self._log_normalize(accumulators)
-            if logspace_accumulators
-            else self._to_log_weights(accumulators)
+        normalize_in_forward_pass = self._normalize or normalize_in_forward_pass
+        w = self._weights_in_logspace(
+            accumulators, logspace_accumulators, normalize_in_forward_pass
         )
         return logmatmul(x, w)
 
     def weighted_children(
-        self, x: tf.Tensor, accumulators: tf.Tensor, logspace_accumulators: bool
+        self,
+        x: tf.Tensor,
+        accumulators: tf.Tensor,
+        logspace_accumulators: bool,
+        normalize_in_forward_pass: bool,
     ) -> tf.Tensor:
         """
         Compute weighted children, without summing over the final axis.
@@ -134,20 +199,23 @@ class SumOpGradBackprop(SumOpBase):
         Args:
             x: Input Tensor
             accumulators: Accumulators, can be seen as unnormalized representations of weights.
-            logspace_accumulators: Whether or not accumulators are represented in logspaace.
+            logspace_accumulators: Whether or not accumulators are represented in logspace.
+            normalize_in_forward_pass: Whether weights should be normalized during forward inference.
 
         Returns:
             A Tensor with the weighted sums.
         """
-        w = (
-            self._log_normalize(accumulators)
-            if logspace_accumulators
-            else self._to_log_weights(accumulators)
+        w = self._weights_in_logspace(
+            accumulators, logspace_accumulators, normalize_in_forward_pass
         )
         return x + tf.linalg.matrix_transpose(w)
 
     def weighted_conv(
-        self, x: tf.Tensor, accumulators: tf.Tensor, logspace_accumulators: bool
+        self,
+        x: tf.Tensor,
+        accumulators: tf.Tensor,
+        logspace_accumulators: bool,
+        normalize_in_forward_pass: bool,
     ) -> tf.Tensor:
         """
         Compute weighted convolutions.
@@ -157,15 +225,14 @@ class SumOpGradBackprop(SumOpBase):
         Args:
             x: Input Tensor
             accumulators: Accumulators, can be seen as unnormalized representations of weights.
-            logspace_accumulators: Whether or not accumulators are represented in logspaace.
+            logspace_accumulators: Whether or not accumulators are represented in logspace.
+            normalize_in_forward_pass: Whether weights should be normalized during forward inference.
 
         Returns:
             A Tensor with the weighted convolutions.
         """
-        w = (
-            self._log_normalize(accumulators)
-            if logspace_accumulators
-            else self._to_log_weights(accumulators)
+        w = self._weights_in_logspace(
+            accumulators, logspace_accumulators, normalize_in_forward_pass
         )
         return logconv1x1_2d(x, w)
 
@@ -192,7 +259,11 @@ class SumOpEMBackprop(SumOpBase):
 
     @_batch_scope_tranpose
     def weighted_sum(
-        self, x: tf.Tensor, accumulators: tf.Tensor, logspace_accumulators: bool
+        self,
+        x: tf.Tensor,
+        accumulators: tf.Tensor,
+        logspace_accumulators: bool,
+        normalize_in_forward_pass: bool,
     ) -> tf.Tensor:
         """
         Compute a weighted sum.
@@ -200,7 +271,8 @@ class SumOpEMBackprop(SumOpBase):
         Args:
             x: Input Tensor
             accumulators: Accumulators, can be seen as unnormalized representations of weights.
-            logspace_accumulators: Whether or not accumulators are represented in logspaace.
+            logspace_accumulators: Whether or not accumulators are represented in logspace.
+            normalize_in_forward_pass: Whether weights should be normalized during forward inference.
 
         Returns:
             A Tensor with the weighted sums.
@@ -212,11 +284,15 @@ class SumOpEMBackprop(SumOpBase):
             raise NotImplementedError(
                 "EM is only implemented for linear space accumulators"
             )
-        w = self._to_logspace_override_grad(accumulators)
+        w = self._to_logspace_override_grad(accumulators, normalize_in_forward_pass)
         return logmatmul(x, w)
 
     def weighted_children(
-        self, x: tf.Tensor, accumulators: tf.Tensor, logspace_accumulators: bool
+        self,
+        x: tf.Tensor,
+        accumulators: tf.Tensor,
+        logspace_accumulators: bool,
+        normalize_in_forward_pass: bool,
     ) -> tf.Tensor:
         """
         Compute weighted children, without summing over the final axis.
@@ -226,7 +302,8 @@ class SumOpEMBackprop(SumOpBase):
         Args:
             x: Input Tensor
             accumulators: Accumulators, can be seen as unnormalized representations of weights.
-            logspace_accumulators: Whether or not accumulators are represented in logspaace.
+            logspace_accumulators: Whether or not accumulators are represented in logspace.
+            normalize_in_forward_pass: Whether weights should be normalized during forward inference.
 
         Returns:
             A Tensor with the weighted sums.
@@ -238,12 +315,16 @@ class SumOpEMBackprop(SumOpBase):
             raise NotImplementedError(
                 "EM is only implemented for linear space accumulators"
             )
-        w = self._to_logspace_override_grad(accumulators)
+        w = self._to_logspace_override_grad(accumulators, normalize_in_forward_pass)
         with tf.name_scope("PairwiseLogMultiply"):
             return x + tf.linalg.matrix_transpose(w)
 
     def weighted_conv(
-        self, x: tf.Tensor, accumulators: tf.Tensor, logspace_accumulators: bool
+        self,
+        x: tf.Tensor,
+        accumulators: tf.Tensor,
+        logspace_accumulators: bool,
+        normalize_in_forward_pass: bool,
     ) -> tf.Tensor:
         """
         Compute weighted convolutions.
@@ -253,7 +334,8 @@ class SumOpEMBackprop(SumOpBase):
         Args:
             x: Input Tensor
             accumulators: Accumulators, can be seen as unnormalized representations of weights.
-            logspace_accumulators: Whether or not accumulators are represented in logspaace.
+            logspace_accumulators: Whether or not accumulators are represented in logspace.
+            normalize_in_forward_pass: Whether weights should be normalized during forward inference.
 
         Returns:
             A Tensor with the weighted convolutions.
@@ -265,7 +347,7 @@ class SumOpEMBackprop(SumOpBase):
             raise NotImplementedError(
                 "EM is only implemented for linear space accumulators"
             )
-        w = self._to_logspace_override_grad(accumulators)
+        w = self._to_logspace_override_grad(accumulators, normalize_in_forward_pass)
         return logconv1x1_2d(x, w)
 
     def default_logspace_accumulators(self) -> bool:
@@ -292,7 +374,11 @@ class SumOpHardEMBackprop(SumOpBase):
 
     @_batch_scope_tranpose
     def weighted_sum(
-        self, x: tf.Tensor, accumulators: tf.Tensor, logspace_accumulators: bool
+        self,
+        x: tf.Tensor,
+        accumulators: tf.Tensor,
+        logspace_accumulators: bool,
+        normalize_in_forward_pass: bool,
     ) -> tf.Tensor:
         """
         Compute a weighted sum.
@@ -300,7 +386,8 @@ class SumOpHardEMBackprop(SumOpBase):
         Args:
             x: Input Tensor
             accumulators: Accumulators, can be seen as unnormalized representations of weights.
-            logspace_accumulators: Whether or not accumulators are represented in logspaace.
+            logspace_accumulators: Whether or not accumulators are represented in logspace.
+            normalize_in_forward_pass: Whether weights should be normalized during forward inference.
 
         Returns:
             A Tensor with the weighted sums.
@@ -318,7 +405,11 @@ class SumOpHardEMBackprop(SumOpBase):
             x: tf.Tensor, accumulators: tf.Tensor
         ) -> Tuple[tf.Tensor, Callable[[tf.Tensor], Tuple[tf.Tensor, tf.Tensor]]]:
             with tf.name_scope("HardEMForwardPass"):
-                w = self._to_log_weights(accumulators)
+                w = (
+                    self._to_log_weights(accumulators)
+                    if normalize_in_forward_pass
+                    else tf.math.log(accumulators)
+                )
                 # Pairwise product in forward pass
                 x = tf.expand_dims(x, axis=3)
                 w = tf.expand_dims(tf.linalg.matrix_transpose(w), axis=2)
@@ -376,14 +467,24 @@ class SumOpHardEMBackprop(SumOpBase):
                 child_counts = tf.reduce_sum(per_sample_weight_counts, axis=3)
                 weight_counts = tf.reduce_sum(per_sample_weight_counts, axis=2)
 
-                return child_counts, tf.transpose(weight_counts, (0, 1, 3, 2))
+                weight_counts = accumulators * tf.linalg.matrix_transpose(weight_counts)
+
+                weight_counts /= (
+                    tf.reduce_sum(tf.abs(weight_counts), axis=2, keepdims=True) + 1e-16
+                )
+
+                return child_counts, weight_counts
 
             return out, grad
 
         return _inner_fn(x, accumulators)
 
     def weighted_children(
-        self, x: tf.Tensor, accumulators: tf.Tensor, logspace_accumulators: bool
+        self,
+        x: tf.Tensor,
+        accumulators: tf.Tensor,
+        logspace_accumulators: bool,
+        normalize_in_forward_pass: bool,
     ) -> tf.Tensor:
         """
         Compute weighted children, without summing over the final axis.
@@ -393,7 +494,8 @@ class SumOpHardEMBackprop(SumOpBase):
         Args:
             x: Input Tensor
             accumulators: Accumulators, can be seen as unnormalized representations of weights.
-            logspace_accumulators: Whether or not accumulators are represented in logspaace.
+            logspace_accumulators: Whether or not accumulators are represented in logspace.
+            normalize_in_forward_pass: Whether weights should be normalized during forward inference.
 
         Returns:
             A Tensor with the weighted sums.
@@ -405,13 +507,17 @@ class SumOpHardEMBackprop(SumOpBase):
             raise NotImplementedError(
                 "EM is only implemented for linear space accumulators"
             )
-        w = self._to_logspace_override_grad(accumulators)
+        w = self._to_logspace_override_grad(accumulators, normalize_in_forward_pass)
         with tf.name_scope("PairwiseLogMultiply"):
             return x + tf.linalg.matrix_transpose(w)
 
     @_batch_scope_tranpose
     def weighted_conv(
-        self, x: tf.Tensor, accumulators: tf.Tensor, logspace_accumulators: bool
+        self,
+        x: tf.Tensor,
+        accumulators: tf.Tensor,
+        logspace_accumulators: bool,
+        normalize_in_forward_pass: bool,
     ) -> tf.Tensor:
         """
         Compute weighted convolutions.
@@ -421,7 +527,8 @@ class SumOpHardEMBackprop(SumOpBase):
         Args:
             x: Input Tensor
             accumulators: Accumulators, can be seen as unnormalized representations of weights.
-            logspace_accumulators: Whether or not accumulators are represented in logspaace.
+            logspace_accumulators: Whether or not accumulators are represented in logspace.
+            normalize_in_forward_pass: Whether weights should be normalized during forward inference.
 
         Returns:
             A Tensor with the weighted convolutions.
@@ -439,7 +546,11 @@ class SumOpHardEMBackprop(SumOpBase):
             x: tf.Tensor, accumulators: tf.Tensor
         ) -> Tuple[tf.Tensor, Callable[[tf.Tensor], Tuple[tf.Tensor, tf.Tensor]]]:
             with tf.name_scope("HardEMForwardPass"):
-                w = self._to_log_weights(accumulators)
+                w = (
+                    self._to_log_weights(accumulators)
+                    if normalize_in_forward_pass
+                    else tf.math.log(normalize_in_forward_pass)
+                )
                 # Pairwise product in forward pass
                 x = tf.expand_dims(x, axis=3)
                 w = tf.expand_dims(tf.linalg.matrix_transpose(w), axis=2)
@@ -499,7 +610,13 @@ class SumOpHardEMBackprop(SumOpBase):
                 # Sum over spatial axes
                 weight_counts = tf.reduce_sum(weight_counts, axis=[0, 1], keepdims=True)
 
-                return child_counts, tf.linalg.matrix_transpose(weight_counts)
+                weight_counts = accumulators * tf.linalg.matrix_transpose(weight_counts)
+
+                weight_counts /= (
+                    tf.reduce_sum(tf.abs(weight_counts), axis=2, keepdims=True) + 1e-16
+                )
+
+                return child_counts, weight_counts
 
             return out, grad
 
@@ -531,9 +648,12 @@ class SumOpUnweightedHardEMBackprop(SumOpBase):
     def __init__(self, sample_prob: Optional[Union[float, tf.Tensor]] = None):
         self.sample_prob = sample_prob
 
-    @_batch_scope_tranpose
     def weighted_sum(
-        self, x: tf.Tensor, accumulators: tf.Tensor, logspace_accumulators: bool
+        self,
+        x: tf.Tensor,
+        accumulators: tf.Tensor,
+        logspace_accumulators: bool,
+        normalize_in_forward_pass: bool,
     ) -> tf.Tensor:
         """
         Compute a weighted sum.
@@ -541,7 +661,8 @@ class SumOpUnweightedHardEMBackprop(SumOpBase):
         Args:
             x: Input Tensor
             accumulators: Accumulators, can be seen as unnormalized representations of weights.
-            logspace_accumulators: Whether or not accumulators are represented in logspaace.
+            logspace_accumulators: Whether or not accumulators are represented in logspace.
+            normalize_in_forward_pass: Whether weights should be normalized during forward inference.
 
         Returns:
             A Tensor with the weighted sums.
@@ -560,7 +681,11 @@ class SumOpUnweightedHardEMBackprop(SumOpBase):
         ) -> Tuple[tf.Tensor, Callable[[tf.Tensor], Tuple[tf.Tensor, tf.Tensor]]]:
 
             # Normalized
-            weights = self._to_log_weights(accumulators)
+            weights = (
+                self._to_log_weights(accumulators)
+                if normalize_in_forward_pass
+                else tf.math.log(accumulators)
+            )
 
             out = logmatmul(x, weights)
 
@@ -600,6 +725,13 @@ class SumOpUnweightedHardEMBackprop(SumOpBase):
                 weight_counts = tf.matmul(
                     winning_child_per_scope_one_hot, parent_counts, transpose_a=True
                 )
+
+                weight_counts = accumulators * weight_counts
+
+                weight_counts /= (
+                    tf.reduce_sum(tf.abs(weight_counts), axis=2, keepdims=True) + 1e-16
+                )
+
                 return child_counts, weight_counts
 
             return out, grad
@@ -607,7 +739,11 @@ class SumOpUnweightedHardEMBackprop(SumOpBase):
         return _inner_fn(x, accumulators)
 
     def weighted_children(
-        self, x: tf.Tensor, accumulators: tf.Tensor, logspace_accumulators: bool
+        self,
+        x: tf.Tensor,
+        accumulators: tf.Tensor,
+        logspace_accumulators: bool,
+        normalize_in_forward_pass: bool,
     ) -> tf.Tensor:
         """
         Compute weighted children, without summing over the final axis.
@@ -617,7 +753,8 @@ class SumOpUnweightedHardEMBackprop(SumOpBase):
         Args:
             x: Input Tensor
             accumulators: Accumulators, can be seen as unnormalized representations of weights.
-            logspace_accumulators: Whether or not accumulators are represented in logspaace.
+            logspace_accumulators: Whether or not accumulators are represented in logspace.
+            normalize_in_forward_pass: Whether weights should be normalized during forward inference.
 
         Returns:
             A Tensor with the weighted sums.
@@ -629,12 +766,16 @@ class SumOpUnweightedHardEMBackprop(SumOpBase):
             raise NotImplementedError(
                 "EM is only implemented for linear space accumulators"
             )
-        w = self._to_logspace_override_grad(accumulators)
+        w = self._to_logspace_override_grad(accumulators, normalize_in_forward_pass)
         with tf.name_scope("PairwiseLogMultiply"):
             return x + tf.linalg.matrix_transpose(w)
 
     def weighted_conv(
-        self, x: tf.Tensor, accumulators: tf.Tensor, logspace_accumulators: bool
+        self,
+        x: tf.Tensor,
+        accumulators: tf.Tensor,
+        logspace_accumulators: bool,
+        normalize_in_forward_pass: bool,
     ) -> tf.Tensor:
         """
         Compute weighted convolutions.
@@ -644,7 +785,8 @@ class SumOpUnweightedHardEMBackprop(SumOpBase):
         Args:
             x: Input Tensor
             accumulators: Accumulators, can be seen as unnormalized representations of weights.
-            logspace_accumulators: Whether or not accumulators are represented in logspaace.
+            logspace_accumulators: Whether or not accumulators are represented in logspace.
+            normalize_in_forward_pass: Whether weights should be normalized during forward inference.
 
         Returns:
             A Tensor with the weighted convolutions.
@@ -663,7 +805,11 @@ class SumOpUnweightedHardEMBackprop(SumOpBase):
         ) -> Tuple[tf.Tensor, Callable[[tf.Tensor], Tuple[tf.Tensor, tf.Tensor]]]:
 
             # Normalized
-            weights = self._to_log_weights(accumulators)
+            weights = (
+                self._to_log_weights(accumulators)
+                if normalize_in_forward_pass
+                else tf.math.log(accumulators)
+            )
 
             out = logmatmul(x, weights)
 
@@ -704,6 +850,13 @@ class SumOpUnweightedHardEMBackprop(SumOpBase):
                     winning_child_per_scope_one_hot, parent_counts, transpose_a=True
                 )
                 weight_counts = tf.reduce_sum(weight_counts, axis=[0, 1], keepdims=True)
+
+                weight_counts = accumulators * tf.linalg.matrix_transpose(weight_counts)
+
+                weight_counts /= (
+                    tf.reduce_sum(tf.abs(weight_counts), axis=2, keepdims=True) + 1e-16
+                )
+
                 return child_counts, weight_counts
 
             return out, grad

--- a/libspn_keras/sum_ops.py
+++ b/libspn_keras/sum_ops.py
@@ -146,17 +146,12 @@ class SumOpGradBackprop(SumOpBase):
     Args:
             logspace_accumulators: If provided overrides default log-space choice. For a
                 ``SumOpGradBackprop`` the default is ``True``
-            normalize_in_forward_pass: If provided overrides normalize that would otherwise be
-                determined from the constraints that are used for a sum layer's weights.
     """
 
     def __init__(
-        self,
-        logspace_accumulators: Optional[bool] = None,
-        normalize_in_forward_pass: Optional[bool] = None,
+        self, logspace_accumulators: Optional[bool] = None,
     ):
         self._logspace_accumulators = logspace_accumulators
-        self._normalize = normalize_in_forward_pass
 
     @_batch_scope_tranpose
     def weighted_sum(
@@ -178,7 +173,6 @@ class SumOpGradBackprop(SumOpBase):
         Returns:
             A Tensor with the weighted sums.
         """
-        normalize_in_forward_pass = self._normalize or normalize_in_forward_pass
         w = self._weights_in_logspace(
             accumulators, logspace_accumulators, normalize_in_forward_pass
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "libspn-keras"
-version = "0.4.0"
+version = "0.5.0"
 description = "LibSPN-Keras: A fledxible and scalable library for layer-based building and training of Sum-Product Networks"
 license = "MIT"
 homepage = "https://github.com/pronobis/libspn-keras"


### PR DESCRIPTION
- Add `GreaterEqualEpsilonNormalized` constraint for linear accumulators
- Rename `LogNormalize` constraint to `LogNormalized`
- Normalize gradients in EM sum ops
- Add `Dirichlet` initializer
- No longer need to specify `factors` for `PermuteAndPadScopesRandom` if used with `SequentialSumProductNetwork`
- No longer need to add `Undecompose` in a region SPN when connecting to a `RootSum`